### PR TITLE
Missing `baseOptions` property in code sample

### DIFF
--- a/quickstart/integrate-in-less-than-a-minute.md
+++ b/quickstart/integrate-in-less-than-a-minute.md
@@ -53,7 +53,7 @@ const configuration = new Configuration({
   apiKey: process.env.OPENAI_API_KEY,
   // Add a basePath to the Configuartion
 <strong>  basePath: "https://oai.hconeai.com/v1",
-</strong>  {
+</strong>  baseOptions: {
     headers: {
       // Add your Helicone API Key
 <strong>      "Helicone-Auth": "Bearer HELICONE_API_KEY",


### PR DESCRIPTION
The node js code sample was not working out of the box it was missing a `baseOptions` property.